### PR TITLE
Adding config features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ This is a Work In Progress, not ready for production (headers are not cached as 
 ```
 var cache = require('restify-cache');
 cache.config({
-    redisPort: 6379,        //default: '6379'
-    redisHost: 'localhost', //default: 'localhost'
-    redisOptions: {},       //optional
-    ttl: 60 * 60            //default:  60 * 60; in seconds
+    redisPort: 6379,            //Number (default: '6379')
+    redisHost: 'localhost',     //String (default: 'localhost')
+    redisOptions: {},           //Object (optional)
+    redisAuth: 'password'       //String (optional)
+    prefix: 'myname',           //String (optional, this will add a string prefix to the redis key)
+    cacheHeader: 'x-api-key',   //String (optional, this will cache any request with this header key)
+    cacheMethods: ['GET']       //Array  (optional, will only cache specified request methods; default ['GET']
+    ttl: 60 * 60                //Number (optional, default:  60 * 60; in seconds)
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ exports.config = function (cfg) {
   config = cfg || {};
   config.redisPort = config.redisPort || 6379;
   config.redisHost = config.redisHost || 'localhost';
-  config.auth = config.auth || null;
+  config.redisAuth = config.redisAuth || null;
   config.ttl = config.ttl || 60 * 60; //1 hour
   config.cacheMethods = (config.cacheMethods) ? _.map(config.cacheMethods, function(s){return s.toUpperCase()}) : ['GET']; // default to only caching GET requests
   config.cacheHeader = config.cacheHeader || false; // caching on an arbitrary header
@@ -24,8 +24,8 @@ exports.config = function (cfg) {
   HEADER_PREFIX += config.prefix + '_' || '';
 
   // check if redis auth was provided
-  if(config.auth){
-    client.auth(config.auth)
+  if(config.redisAuth){
+    client.auth(config.redisAuth)
   }
 
   return client;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,14 @@ exports.config = function (cfg) {
   config = cfg || {};
   config.redisPort = config.redisPort || 6379;
   config.redisHost = config.redisHost || 'localhost';
+  config.auth = config.auth || null;
   config.ttl = config.ttl || 60 * 60; //1 hour
   client = redis.createClient(config.redisPort, config.redisHost, config.redisOptions);
+  if(config.auth){
+    client.auth(config.auth, function(){
+      console.log('REDIS AUTHED')
+    })
+  }
 };
 
 /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ exports.before = function (req, res, next) {
     return next();
   }
 
+  // check for arbitrary headers to cache on
   if(config.cacheHeader && _.contains(_.keys(req.headers), config.cacheHeader)){
     _PAYLOAD_PREFIX = _PAYLOAD_PREFIX + req.headers[config.cacheHeader];
     _HEADER_PREFIX = _HEADER_PREFIX + req.headers[config.cacheHeader];
@@ -90,6 +91,12 @@ exports.after = function(req, res, route, error, cb) {
   var _PAYLOAD_PREFIX = PAYLOAD_PREFIX,
     _HEADER_PREFIX = HEADER_PREFIX;
 
+  // if config wasn't called, lets set it now.
+  if (!client) {
+      exports.config();
+  }
+
+  // check for arbitrary headers to cache on
   if(config.cacheHeader && _.contains(_.keys(req.headers), config.cacheHeader)){
     _PAYLOAD_PREFIX = _PAYLOAD_PREFIX + req.headers[config.cacheHeader];
     _HEADER_PREFIX = _HEADER_PREFIX + req.headers[config.cacheHeader];
@@ -103,12 +110,6 @@ exports.after = function(req, res, route, error, cb) {
     return;
   }
 
-  // if config wasn't called, lets set it now.
-  if (!client) {
-    exports.config();
-  }
-  // save the headers
-
   client.set(_HEADER_PREFIX + req.url, JSON.stringify(res.headers()), function(err){
     client.expire(_HEADER_PREFIX + req.url, determineCacheTTL(res));
 
@@ -118,8 +119,6 @@ exports.after = function(req, res, route, error, cb) {
     });
 
   });
-
-
 
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var redis = require("redis"),
+  _ = require('lodash'),
   client,
   config;
 
@@ -13,29 +14,52 @@ exports.config = function (cfg) {
   config.redisHost = config.redisHost || 'localhost';
   config.auth = config.auth || null;
   config.ttl = config.ttl || 60 * 60; //1 hour
+  config.cacheMethods = (config.cacheMethods) ? _.map(config.cacheMethods, function(s){return s.toUpperCase()}) : ['GET']; // default to only caching GET requests
+  config.cacheHeader = config.cacheHeader || false; // caching on an arbitrary header
+
   client = redis.createClient(config.redisPort, config.redisHost, config.redisOptions);
+
+  // attach additional prefix if needed
+  PAYLOAD_PREFIX += config.prefix + '_' || '';
+  HEADER_PREFIX += config.prefix + '_' || '';
+
+  // check if redis auth was provided
   if(config.auth){
-    client.auth(config.auth, function(){
-      console.log('REDIS AUTHED')
-    })
+    client.auth(config.auth)
   }
+
+  return client;
 };
 
 /*
  * Checks if we have the response in Redis
  * */
 exports.before = function (req, res, next) {
-  var url;
+  var url,
+    _PAYLOAD_PREFIX = PAYLOAD_PREFIX,
+    _HEADER_PREFIX = HEADER_PREFIX;
+
   // if config wasn't called, lets set it now.
   if (!client) {
     exports.config();
   }
+
+  // check if we are caching this request method
+  if(!_.contains(config.cacheMethods, req.method)){
+    return next();
+  }
+
+  if(config.cacheHeader && _.contains(_.keys(req.headers), config.cacheHeader)){
+    _PAYLOAD_PREFIX = _PAYLOAD_PREFIX + req.headers[config.cacheHeader];
+    _HEADER_PREFIX = _HEADER_PREFIX + req.headers[config.cacheHeader];
+  }
+
   url = req.url;
-  client.get(PAYLOAD_PREFIX + url, function(err, payload) {
+  client.get(_PAYLOAD_PREFIX + url, function(err, payload) {
     if (err) {
       return next(err);
     }
-    client.get(HEADER_PREFIX + url, function(err, headers) {
+    client.get(_HEADER_PREFIX + url, function(err, headers) {
       var parsedHeaders,
         headerItem;
 
@@ -60,16 +84,24 @@ exports.before = function (req, res, next) {
 };
 
 /*
-* Put the response into Redis
-* */
+ * Put the response into Redis
+ * */
 exports.after = function(req, res, route, error, cb) {
-    if (error) {
-        if (cb) {
-            return cb(error);
-        }
+  var _PAYLOAD_PREFIX = PAYLOAD_PREFIX,
+    _HEADER_PREFIX = HEADER_PREFIX;
 
-        return;
+  if(config.cacheHeader && _.contains(_.keys(req.headers), config.cacheHeader)){
+    _PAYLOAD_PREFIX = _PAYLOAD_PREFIX + req.headers[config.cacheHeader];
+    _HEADER_PREFIX = _HEADER_PREFIX + req.headers[config.cacheHeader];
+  }
+
+  if (error) {
+    if (cb) {
+      return cb(error);
     }
+
+    return;
+  }
 
   // if config wasn't called, lets set it now.
   if (!client) {
@@ -77,12 +109,12 @@ exports.after = function(req, res, route, error, cb) {
   }
   // save the headers
 
-  client.set(HEADER_PREFIX + req.url, JSON.stringify(res.headers()), function(err ){
-    client.expire(HEADER_PREFIX + req.url, determineCacheTTL(res));
+  client.set(_HEADER_PREFIX + req.url, JSON.stringify(res.headers()), function(err){
+    client.expire(_HEADER_PREFIX + req.url, determineCacheTTL(res));
 
     // save the payload
-    client.set(PAYLOAD_PREFIX + req.url, res._data, function(err ){
-      client.expire(PAYLOAD_PREFIX + req.url, determineCacheTTL(res), cb);
+    client.set(_PAYLOAD_PREFIX + req.url, res._data, function(err){
+      client.expire(_PAYLOAD_PREFIX + req.url, determineCacheTTL(res), cb);
     });
 
   });
@@ -92,15 +124,15 @@ exports.after = function(req, res, route, error, cb) {
 };
 
 function determineCacheTTL(res) {
-    var cacheControl = res.getHeader('cache-control');
+  var cacheControl = res.getHeader('cache-control');
 
-    if (cacheControl) {
-        var maxAgeMatch = /max-age=(\d+)/.exec(cacheControl);
+  if (cacheControl) {
+    var maxAgeMatch = /max-age=(\d+)/.exec(cacheControl);
 
-        if (maxAgeMatch) {
-            return maxAgeMatch[1];
-        }
+    if (maxAgeMatch) {
+      return maxAgeMatch[1];
     }
+  }
 
-    return config.ttl;
+  return config.ttl;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ exports.config = function (cfg) {
   config = cfg || {};
   config.redisPort = config.redisPort || 6379;
   config.redisHost = config.redisHost || 'localhost';
-  config.redisAuth = config.redisAuth || null;
+  config.redisAuth = config.redisAuth || false;
   config.ttl = config.ttl || 60 * 60; //1 hour
   config.cacheMethods = (config.cacheMethods) ? _.map(config.cacheMethods, function(s){return s.toUpperCase()}) : ['GET']; // default to only caching GET requests
   config.cacheHeader = config.cacheHeader || false; // caching on an arbitrary header
@@ -20,8 +20,10 @@ exports.config = function (cfg) {
   client = redis.createClient(config.redisPort, config.redisHost, config.redisOptions);
 
   // attach additional prefix if needed
-  PAYLOAD_PREFIX += config.prefix + '_' || '';
-  HEADER_PREFIX += config.prefix + '_' || '';
+  if(config.prefix){
+    PAYLOAD_PREFIX += config.prefix + '_';
+    HEADER_PREFIX += config.prefix + '_';
+  }
 
   // check if redis auth was provided
   if(config.redisAuth){
@@ -44,9 +46,9 @@ exports.before = function (req, res, next) {
     exports.config();
   }
 
-  // check if we are caching this request method
-  if(!_.contains(config.cacheMethods, req.method)){
-    return next();
+  // check if we aren't caching this request method and pass over
+  if(req.method && !_.contains(config.cacheMethods, req.method)){
+      return next();
   }
 
   // check for arbitrary headers to cache on
@@ -91,23 +93,30 @@ exports.after = function(req, res, route, error, cb) {
   var _PAYLOAD_PREFIX = PAYLOAD_PREFIX,
     _HEADER_PREFIX = HEADER_PREFIX;
 
+  if (error) {
+      if (cb) {
+          return cb(error);
+      }
+      return;
+  }
+
   // if config wasn't called, lets set it now.
   if (!client) {
       exports.config();
+  }
+
+  // check if we aren't caching this request method and pass over
+  if(req.method && !_.contains(config.cacheMethods, req.method)){
+      if (cb) {
+          return cb(null);
+      }
+      return;
   }
 
   // check for arbitrary headers to cache on
   if(config.cacheHeader && _.contains(_.keys(req.headers), config.cacheHeader)){
     _PAYLOAD_PREFIX = _PAYLOAD_PREFIX + req.headers[config.cacheHeader];
     _HEADER_PREFIX = _HEADER_PREFIX + req.headers[config.cacheHeader];
-  }
-
-  if (error) {
-    if (cb) {
-      return cb(error);
-    }
-
-    return;
   }
 
   client.set(_HEADER_PREFIX + req.url, JSON.stringify(res.headers()), function(err){

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   },
   "homepage": "https://github.com/gergelyke/restify-cache",
   "dependencies": {
-    "redis": "~0.10.0",
-    "hiredis": "~0.1.16"
+    "hiredis": "~0.1.16",
+    "lodash": "~3.5.0",
+    "redis": "~0.10.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1",

--- a/test/specs.js
+++ b/test/specs.js
@@ -1,13 +1,15 @@
-describe('Redis-cache', function () {
+describe('Redis-cache', function() {
 
-  var testUrl = '/testing-the-redis-cache';
+    var testUrl = '/testing-the-redis-cache';
 
     describe("errors do not write cache", function() {
-        it("do not throw if callback is not provided", function (done) {
+        it("do not throw if callback is not provided", function(done) {
             var ex = new Error('expected');
 
-            var fn = function(){
-                cache.after({url: testUrl}, null, null, ex)
+            var fn = function() {
+                cache.after({
+                    url: testUrl
+                }, null, null, ex)
             };
 
             chai.expect(fn).to.not.throw();
@@ -15,13 +17,15 @@ describe('Redis-cache', function () {
             done();
         });
 
-        it("do not write cache in after", function (done) {
+        it("do not write cache in after", function(done) {
             var ex = new Error('expected');
-            cache.after({url: testUrl}, null, null, ex, function (err) {
+            cache.after({
+                url: testUrl
+            }, null, null, ex, function(err) {
 
                 ex.should.be.equal(err);
 
-                redis.get(HEADER_PREFIX + testUrl, function (err, data) {
+                redis.get(HEADER_PREFIX + testUrl, function(err, data) {
                     if (err) {
                         return done(err);
                     }
@@ -34,257 +38,272 @@ describe('Redis-cache', function () {
         });
     });
 
-    describe('saves', function () {
+    describe('saves', function() {
 
-
-    afterEach(function (done) {
-      redis.del(HEADER_PREFIX + testUrl, function (err) {
-        if (err) {
-          return done(err);
-        }
-        redis.del(PAYLOAD_PREFIX + testUrl, function (err) {
-          done(err);
+        afterEach(function(done) {
+            redis.del(HEADER_PREFIX + testUrl, function(err) {
+                if (err) {
+                    return done(err);
+                }
+                redis.del(PAYLOAD_PREFIX + testUrl, function(err) {
+                    done(err);
+                });
+            });
         });
-      });
-    });
 
-      describe("cache-control not specified", function () {
-          it('responseheaders', function (done) {
-              cache.after({
-                  url: testUrl
-              }, {
-                  headers: function () {
-                      return {
-                          'Accept': 'application/xml'
-                      };
-                  },
-                  header: function(key, value) {
-                      key.should.equal('X-Cache');
-                      value.should.equal('MISS');
-                  },
-                  getHeader: function () {
-                      return undefined;
-                  }
-              }, null, null, function (err) {
-                  if (err) {
-                      return done(err);
-                  }
-                  redis.get(HEADER_PREFIX + testUrl, function (err, data) {
-                      if (err) {
-                          return done(err);
-                      }
-                      if (!data) {
-                          return done('No data!')
-                      }
-                      data.should.equal('{"Accept":"application/xml"}');
+        describe("cache-control not specified", function() {
+            it('responseheaders', function(done) {
+                cache.after({
+                    url: testUrl
+                }, {
+                    headers: function() {
+                        return {
+                            'Accept': 'application/xml'
+                        };
+                    },
+                    method: function(){
+                        return 'GET'
+                    },
+                    header: function(key, value) {
+                        key.should.equal('X-Cache');
+                        value.should.equal('MISS');
+                    },
+                    getHeader: function() {
+                        return undefined;
+                    }
+                }, null, null, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    redis.get(HEADER_PREFIX + testUrl, function(err, data) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (!data) {
+                            return done('No data!')
+                        }
+                        data.should.equal('{"Accept":"application/xml"}');
 
-                      redis.ttl(HEADER_PREFIX + testUrl, function (err, data) {
-                          if (err) {
-                              return done(err);
-                          }
-                          if (!data) {
-                              return done('No data!')
-                          }
-                          data.should.equal(3600);
+                        redis.ttl(HEADER_PREFIX + testUrl, function(err, data) {
+                            if (err) {
+                                return done(err);
+                            }
+                            if (!data) {
+                                return done('No data!')
+                            }
+                            data.should.equal(3600);
 
-                          done();
-                      });
-                  });
-              })
-          });
+                            done();
+                        });
+                    });
+                })
+            });
 
-          it('payload', function (done) {
-              cache.after({
-                  url: testUrl
-              }, {
-                  headers: function () {
-                      return {};
-                  },
-                  header: function(key, value) {
-                      key.should.equal('X-Cache');
-                      value.should.equal('MISS');
-                  },
-                  getHeader: function () {
-                      return undefined;
-                  },
-                  _data: JSON.stringify({
-                      'testing': 1,
-                      'expect': 'works'
-                  })
-              }, null, null, function (err) {
-                  if (err) {
-                      return done(err);
-                  }
-                  redis.get(PAYLOAD_PREFIX + testUrl, function (err, data) {
-                      if (err) {
-                          return done(err);
-                      }
-                      if (!data) {
-                          return done('No data!')
-                      }
-                      data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
+            it('payload', function(done) {
+                cache.after({
+                    url: testUrl
+                }, {
+                    headers: function() {
+                        return {};
+                    },
+                    method: function(){
+                        return 'GET'
+                    },
+                    header: function(key, value) {
+                        key.should.equal('X-Cache');
+                        value.should.equal('MISS');
+                    },
+                    getHeader: function() {
+                        return undefined;
+                    },
+                    _data: JSON.stringify({
+                        'testing': 1,
+                        'expect': 'works'
+                    })
+                }, null, null, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    redis.get(PAYLOAD_PREFIX + testUrl, function(err, data) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (!data) {
+                            return done('No data!')
+                        }
+                        data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
 
-                      redis.ttl(PAYLOAD_PREFIX + testUrl, function (err, data) {
-                          if (err) {
-                              return done(err);
-                          }
-                          if (!data) {
-                              return done('No data!')
-                          }
-                          data.should.equal(3600);
-                          done();
-                      });
-                  });
-              });
-          });
-      });
-
-      describe("cache-control specified", function () {
-          it('responseheaders', function (done) {
-              cache.after({
-                  url: testUrl
-              }, {
-                  headers: function () {
-                      return {
-                          'Accept': 'application/xml',
-                          'Cache-Control': 'public, max-age=54321'
-                      };
-                  },
-                  header: function(key, value) {
-                      key.should.equal('X-Cache');
-                      value.should.equal('MISS');
-                  },
-                  getHeader: function () {
-                      return 'public, max-age=54321';
-                  }
-              }, null, null, function (err) {
-                  if (err) {
-                      return done(err);
-                  }
-                  redis.get(HEADER_PREFIX + testUrl, function (err, data) {
-                      if (err) {
-                          return done(err);
-                      }
-                      if (!data) {
-                          return done('No data!')
-                      }
-                      data.should.equal('{"Accept":"application/xml","Cache-Control":"public, max-age=54321"}');
-
-                      redis.ttl(HEADER_PREFIX + testUrl, function (err, data) {
-                          if (err) {
-                              return done(err);
-                          }
-                          if (!data) {
-                              return done('No data!')
-                          }
-                          data.should.equal(54321);
-                      });
-                      done();
-                  });
-              })
-          });
-
-          it('payload', function (done) {
-              cache.after({
-                  url: testUrl
-              }, {
-                  headers: function () {
-                      return {};
-                  },
-                  header: function(key, value) {
-                      key.should.equal('X-Cache');
-                      value.should.equal('MISS');
-                  },
-                  getHeader: function () {
-                      return 'public, max-age=1';
-                  },
-                  _data: JSON.stringify({
-                      'testing': 1,
-                      'expect': 'works'
-                  })
-              }, null, null, function (err) {
-                  if (err) {
-                      return done(err);
-                  }
-                  redis.get(PAYLOAD_PREFIX + testUrl, function (err, data) {
-                      if (err) {
-                          return done(err);
-                      }
-                      if (!data) {
-                          return done('No data!')
-                      }
-                      data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
-
-                      redis.ttl(PAYLOAD_PREFIX + testUrl, function (err, data) {
-                          if (err) {
-                              return done(err);
-                          }
-                          if (!data) {
-                              return done('No data!')
-                          }
-                          data.should.equal(1);
-                      });
-
-                      done();
-                  });
-              });
-          });
-      });
-  });
-  describe('retrieves', function () {
-
-    beforeEach(function (done) {
-      cache.after({
-        url: testUrl
-      }, {
-        headers: function () {
-          return {
-            'Accept': 'application/xml'
-          };
-        },
-        header: function() {
-        },
-        getHeader: function() {
-            return undefined;
-        },
-        _data: JSON.stringify({
-          'testing': 1,
-          'expect': 'works'
-        })
-      }, null, null, done);
-    });
-
-    afterEach(function (done) {
-      redis.del(HEADER_PREFIX + testUrl, function (err) {
-        if (err) {
-          return done(err);
-        }
-        redis.del(PAYLOAD_PREFIX + testUrl, function (err) {
-          done(err);
+                        redis.ttl(PAYLOAD_PREFIX + testUrl, function(err, data) {
+                            if (err) {
+                                return done(err);
+                            }
+                            if (!data) {
+                                return done('No data!')
+                            }
+                            data.should.equal(3600);
+                            done();
+                        });
+                    });
+                });
+            });
         });
-      });
+
+        describe("cache-control specified", function() {
+            it('responseheaders', function(done) {
+                cache.after({
+                    url: testUrl
+                }, {
+                    headers: function() {
+                        return {
+                            'Accept': 'application/xml',
+                            'Cache-Control': 'public, max-age=54321'
+                        };
+                    },
+                    method: function(){
+                        return 'GET'
+                    },
+                    header: function(key, value) {
+                        key.should.equal('X-Cache');
+                        value.should.equal('MISS');
+                    },
+                    getHeader: function() {
+                        return 'public, max-age=54321';
+                    }
+                }, null, null, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    redis.get(HEADER_PREFIX + testUrl, function(err, data) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (!data) {
+                            return done('No data!')
+                        }
+                        data.should.equal('{"Accept":"application/xml","Cache-Control":"public, max-age=54321"}');
+
+                        redis.ttl(HEADER_PREFIX + testUrl, function(err, data) {
+                            if (err) {
+                                return done(err);
+                            }
+                            if (!data) {
+                                return done('No data!')
+                            }
+                            data.should.equal(54321);
+                        });
+                        done();
+                    });
+                })
+            });
+
+            it('payload', function(done) {
+                cache.after({
+                    url: testUrl
+                }, {
+                    headers: function() {
+                        return {};
+                    },
+                    method: function(){
+                        return 'GET'
+                    },
+                    header: function(key, value) {
+                        key.should.equal('X-Cache');
+                        value.should.equal('MISS');
+                    },
+                    getHeader: function() {
+                        return 'public, max-age=1';
+                    },
+                    _data: JSON.stringify({
+                        'testing': 1,
+                        'expect': 'works'
+                    })
+                }, null, null, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    redis.get(PAYLOAD_PREFIX + testUrl, function(err, data) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (!data) {
+                            return done('No data!')
+                        }
+                        data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
+
+                        redis.ttl(PAYLOAD_PREFIX + testUrl, function(err, data) {
+                            if (err) {
+                                return done(err);
+                            }
+                            if (!data) {
+                                return done('No data!')
+                            }
+                            data.should.equal(1);
+                        });
+
+                        done();
+                    });
+                });
+            });
+        });
     });
+    describe('retrieves', function() {
 
-    it('a response', function (done) {
-        var headers = {};
-      cache.before({
-        url: testUrl
-      }, {
-        header: function(key, value) {
-            headers[key] = value;
-        },
-        end: function (data) {
-          data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
+        beforeEach(function(done) {
+            cache.after({
+                url: testUrl
+            }, {
+                headers: function() {
+                    return {
+                        'Accept': 'application/xml'
+                    };
+                },
+                method: function(){
+                    return 'GET'
+                },
+                header: function() {},
+                getHeader: function() {
+                    return undefined;
+                },
+                _data: JSON.stringify({
+                    'testing': 1,
+                    'expect': 'works'
+                })
+            }, null, null, done);
+        });
 
-          headers['X-Cache'].should.equal('HIT');
-          headers['Accept'].should.equal('application/xml');
-          done();
-        },
-        writeHead: function() {}
-      }, function(){
+        afterEach(function(done) {
+            redis.del(HEADER_PREFIX + testUrl, function(err) {
+                if (err) {
+                    return done(err);
+                }
+                redis.del(PAYLOAD_PREFIX + testUrl, function(err) {
+                    done(err);
+                });
+            });
+        });
 
-      });
+        it('a response', function(done) {
+            var headers = {};
+            cache.before({
+                url: testUrl
+            }, {
+                header: function(key, value) {
+                    headers[key] = value;
+                },
+                method: function(){
+                    return 'GET'
+                },
+                end: function(data) {
+                    data.should.equal('{\"testing\":1,\"expect\":\"works\"}');
+
+                    headers['X-Cache'].should.equal('HIT');
+                    headers['Accept'].should.equal('application/xml');
+                    done();
+                },
+                writeHead: function() {}
+            }, function() {
+
+            });
+        });
     });
-  });
-
 });


### PR DESCRIPTION
Overview of what I've added, I know there is a bunch, so feel free to cherry pick:
- Redis auth into config
- Redis key prefix 
  - this suffixes the global prefix, for multiple clients using the same server
- Cache on specific header
  - this might be temporary for adding more header cache options
- Cache on specified request methods
  - Filtering out POST and other request methods you wouldn't normally want to cache the response to
